### PR TITLE
Feature/profile edit

### DIFF
--- a/src/components/AccountModal/ChangePasswordForm.jsx
+++ b/src/components/AccountModal/ChangePasswordForm.jsx
@@ -3,6 +3,7 @@ import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import { EyeCloseIcon, EyeIcon } from "../../icons";
+import { verifyPassword } from "../../services/authService";
 
 const ChangePasswordForm = () => {
   const [formStep, setFormStep] = useState('current');
@@ -14,17 +15,29 @@ const ChangePasswordForm = () => {
   const [showNewPasswordConfirm, setShowNewPasswordConfirm] = useState(false);
   const { updateUserData, closeModal } = useAccountModalStore();
 
-  const handleCurrentPasswordSubmit = (e) => {
+  const handleCurrentPasswordSubmit = async (e) => {
       e.preventDefault();
+
       if (!verify.trim()) {
         alert('현재 비밀번호를 입력해주세요.');
         return;
       }
-      setFormStep('new');
+
+      try {
+        const response = await verifyPassword({ password: verify });
+        const reauthToken = response.data.data.reauthToken;
+
+        sessionStorage.setItem("reauthToken", reauthToken); // 인증 토큰 저장
+        setFormStep('new');
+      } catch (error) {
+        const message = error.response?.data?.message || '비밀번호 인증에 실패했습니다.';
+        alert(message);
+      }
     };
     
-    const handleNewPasswordSubmit = (e) => {
+  const handleNewPasswordSubmit = (e) => {
     e.preventDefault();
+
     if (!password.trim() || !confirm.trim()) {
       alert('모든 필드를 입력해주세요.');
       return;
@@ -33,10 +46,11 @@ const ChangePasswordForm = () => {
       alert('비밀번호가 일치하지 않습니다');
       return;
     }
-      // 실제 확인 로직 필요
-      updateUserData({ password });
-      alert('비밀번호가 변경되었습니다.');
-      closeModal();
+
+    // 실제 변경 API 호출은 아직 연결 전 (updateUserData는 임시)
+    updateUserData({ password });
+    alert('비밀번호가 변경되었습니다.');
+    closeModal();
   };
 
 

--- a/src/components/AccountModal/ChangePasswordForm.jsx
+++ b/src/components/AccountModal/ChangePasswordForm.jsx
@@ -3,7 +3,8 @@ import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import { EyeCloseIcon, EyeIcon } from "../../icons";
-import { verifyPassword } from "../../services/authService";
+import { verifyPassword, changePassword } from "../../services/authService";
+
 
 const ChangePasswordForm = () => {
   const [formStep, setFormStep] = useState('current');
@@ -13,29 +14,29 @@ const ChangePasswordForm = () => {
   const [showPassword, setShowPassword] = useState(false);
   const [showNewPassword, setShowNewPassword] = useState(false);
   const [showNewPasswordConfirm, setShowNewPasswordConfirm] = useState(false);
+
   const { updateUserData, closeModal } = useAccountModalStore();
 
   const handleCurrentPasswordSubmit = async (e) => {
-      e.preventDefault();
+    e.preventDefault();
 
-      if (!verify.trim()) {
-        alert('현재 비밀번호를 입력해주세요.');
-        return;
-      }
+    if (!verify.trim()) {
+      alert('현재 비밀번호를 입력해주세요.');
+      return;
+    }
 
-      try {
-        const response = await verifyPassword({ password: verify });
-        const reauthToken = response.data.data.reauthToken;
+    try {
+      const response = await verifyPassword({ password: verify });
+      const reauthToken = response.data.data.reauthToken;
+      sessionStorage.setItem("reauthToken", reauthToken);
+      setFormStep('new');
+    } catch (error) {
+      const message = error.response?.data?.message || '비밀번호 인증에 실패했습니다.';
+      alert(message);
+    }
+  };
 
-        sessionStorage.setItem("reauthToken", reauthToken); // 인증 토큰 저장
-        setFormStep('new');
-      } catch (error) {
-        const message = error.response?.data?.message || '비밀번호 인증에 실패했습니다.';
-        alert(message);
-      }
-    };
-    
-  const handleNewPasswordSubmit = (e) => {
+  const handleNewPasswordSubmit = async (e) => {
     e.preventDefault();
 
     if (!password.trim() || !confirm.trim()) {
@@ -47,10 +48,24 @@ const ChangePasswordForm = () => {
       return;
     }
 
-    // 실제 변경 API 호출은 아직 연결 전 (updateUserData는 임시)
-    updateUserData({ password });
-    alert('비밀번호가 변경되었습니다.');
-    closeModal();
+    try {
+      const reauthToken = sessionStorage.getItem('reauthToken');
+      if (!reauthToken || reauthToken === 'undefined') {
+        alert('비밀번호 인증이 만료되었습니다. 다시 시도해주세요.');
+        setFormStep('current');
+        return;
+      }
+
+      // ✅ 토큰 제대로 꺼내와졌는지 확인
+      console.log('reauthToken in password submit:', reauthToken);
+
+      await changePassword(password, confirm, reauthToken); // 문제 지점
+      alert('비밀번호가 변경되었습니다.');
+      sessionStorage.removeItem('reauthToken');
+      closeModal();
+    } catch (error) {
+      alert(error.response?.data?.message || '비밀번호 변경에 실패했습니다.');
+    }
   };
 
 
@@ -98,7 +113,7 @@ const ChangePasswordForm = () => {
         <>
           <div className="relative">
             <Input
-              type="password"
+              type={showNewPasswordConfirm ? "text" : "password"}
               placeholder="새 비밀번호"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -117,7 +132,7 @@ const ChangePasswordForm = () => {
           </div>
           <div className="relative">
             <Input
-              type="password"
+              type={showNewPasswordConfirm ? "text" : "password"}
               placeholder="비밀번호 확인"
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}

--- a/src/components/AccountModal/ChangePasswordForm.jsx
+++ b/src/components/AccountModal/ChangePasswordForm.jsx
@@ -113,7 +113,7 @@ const ChangePasswordForm = () => {
         <>
           <div className="relative">
             <Input
-              type={showNewPasswordConfirm ? "text" : "password"}
+              type={showNewPassword ? "text" : "password"}
               placeholder="새 비밀번호"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
@@ -133,7 +133,7 @@ const ChangePasswordForm = () => {
           <div className="relative">
             <Input
               type={showNewPasswordConfirm ? "text" : "password"}
-              placeholder="비밀번호 확인"
+              placeholder="새 비밀번호 확인"
               value={confirm}
               onChange={(e) => setConfirm(e.target.value)}
               className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"

--- a/src/components/AccountModal/ChangePhoneForm.jsx
+++ b/src/components/AccountModal/ChangePhoneForm.jsx
@@ -1,8 +1,14 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import { EyeCloseIcon, EyeIcon } from "../../icons";
+import {
+  verifyPassword,
+  sendVerificationCode,
+  verifyCode,
+  verifyPhoneCodeAndChangeNumber,
+} from '../../services/authService';
 
 const ChangePhoneForm = () => {
   const [formStep, setFormStep] = useState('password');
@@ -12,168 +18,127 @@ const ChangePhoneForm = () => {
   const [showPassword, setShowPassword] = useState(false);
   const { updateUserData, closeModal } = useAccountModalStore();
 
-  const verifyPassword = (pw) => {
-    // 임시로 'password123'을 맞는 비밀번호로 가정
-    return pw === 'password123';
+  // 1단계: 비밀번호 인증
+  const handlePasswordSubmit = async (e) => {
+    e.preventDefault();
+    if (!password.trim()) return alert('비밀번호를 입력해주세요.');
+
+    try {
+      const response = await verifyPassword({ password });
+      const reauthToken = response.data.data.reauthToken;
+      sessionStorage.setItem('reauthToken', reauthToken);
+      setFormStep('phone');
+    } catch (err) {
+      alert(err.response?.data?.message || '비밀번호 인증에 실패했습니다.');
+    }
   };
 
-  // 비밀번호 제출 처리
-  const handlePasswordSubmit = (e) => {
+  // 2단계: 인증코드 전송
+  const handleSendCode = async (e) => {
     e.preventDefault();
-    
-    if (!password.trim()) {
-      alert('비밀번호를 입력해주세요.');
-      return;
-    }
-    
-    if (!verifyPassword(password)) {
-      alert('비밀번호가 일치하지 않습니다.');
-      return;
-    }
-    
-    setFormStep('phone');
-  };
-
-  // 인증코드 전송 처리
-  const handleSendCode = (e) => {
-    e.preventDefault();
-    
-    if (!phone.trim()) {
-      alert('전화번호를 입력해주세요.');
-      return;
-    }
-    
-    // 전화번호 유효성 검사
-    const phoneRegex = /^01([0|1|6|7|8|9])-?([0-9]{3,4})-?([0-9]{4})$/;
+    const phoneRegex = /^010\d{8}$/;
     if (!phoneRegex.test(phone)) {
-      alert('유효한 전화번호 형식이 아닙니다.');
-      return;
+      return alert('전화번호는 010으로 시작하는 11자리 숫자여야 합니다.');
     }
-    
-    alert(`${phone}로 인증코드가 전송되었습니다. (테스트용)`);
-    setFormStep('verify');
+
+    try {
+      await sendVerificationCode(phone);
+      alert(`${phone}로 인증코드를 전송했습니다.`);
+      setFormStep('verify');
+    } catch (err) {
+      alert(err.response?.data?.message || '인증코드 전송에 실패했습니다.');
+    }
   };
 
-  // 인증코드 검증 처리
-  const handleVerifySubmit = (e) => {
+  // 3단계: 인증코드 확인 및 변경 요청
+  const handleVerifySubmit = async (e) => {
     e.preventDefault();
-    
-    if (!code.trim()) {
-      alert('인증코드를 입력해주세요.');
-      return;
+    if (!code.trim()) return alert('인증코드를 입력해주세요.');
+
+    const reauthToken = sessionStorage.getItem('reauthToken');
+      if (!reauthToken) {
+      alert('인증이 만료되었습니다. 다시 시도해주세요.');
+      return setFormStep('password');
     }
-    
-    // 임시로 '123456'을 맞는 인증코드로 가정
-    if (code !== '123456') {
-      alert('인증코드가 일치하지 않습니다.');
-      return;
+
+    try {
+      await verifyCode({ phoneNumber: phone, code });
+
+      await verifyPhoneCodeAndChangeNumber({ phoneNumber: phone, reauthToken });
+
+      alert(`전화번호가 ${phone}으로 변경되었습니다.`);
+      updateUserData({ phone });
+      sessionStorage.removeItem('reauthToken');
+      closeModal();
+    } catch (err) {
+      alert(err.response?.data?.message || '전화번호 변경에 실패했습니다.');
     }
-    
-    updateUserData({ phone });
-    alert(`전화번호가 ${phone}으로 변경되었습니다.`);
-    closeModal();
   };
 
   return (
     <form className="space-y-5 p-4 mt-5">
       {formStep === 'password' && (
         <>
-        <h2 className="text-xl font-semibold text-gray-800">비밀번호를 입력해주세요</h2>
+          <h2 className="text-xl font-semibold text-gray-800">비밀번호를 입력해주세요</h2>
           <div className="relative">
             <Input
-              type={showPassword ? "text" : "password"}
-              placeholder="현재 비밀번호를 입력해주세요"
+              type={showPassword ? 'text' : 'password'}
+              placeholder="현재 비밀번호"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full border border-gray-300 rounded-lg px-4 py-2"
             />
             <span
               onClick={() => setShowPassword(!showPassword)}
-              className="absolute z-30 -translate-y-1/2 cursor-pointer right-4 top-1/2"
+              className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer"
             >
-              {showPassword ? (
-                <EyeIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
-              ) : (
-                <EyeCloseIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
-              )}
+              {showPassword ? <EyeIcon className="size-5" /> : <EyeCloseIcon className="size-5" />}
             </span>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Button
-              onClick={closeModal}
-              className="flex-1 bg-gray-200 text-gray-700 hover:bg-gray-300"
-            >
+            <Button onClick={closeModal} className="bg-gray-200 text-gray-700 hover:bg-gray-300">
               취소
             </Button>
-            <Button
-              type="submit"
-              onClick={handlePasswordSubmit}
-              className="w-full bg-primary text-white rounded-lg py-2 hover:bg-primary-dark transition"
-            >
+            <Button onClick={handlePasswordSubmit} className="bg-primary text-white hover:bg-primary-dark">
               확인
             </Button>
           </div>
         </>
       )}
+
       {formStep === 'phone' && (
         <>
-          <h2 className="text-xl font-semibold text-gray-800">전화번호를 입력해주세요</h2>
-          <div className="grid grid-col-1 grid-flow-col gap-3">
+          <h2 className="text-xl font-semibold text-gray-800">전화번호 입력</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <Input
               type="tel"
+              placeholder="01012345678"
               value={phone}
-              placeholder="010-0000-0000"
               onChange={(e) => setPhone(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              className="w-full border border-gray-300 rounded-lg px-4 py-2"
             />
-            <Button
-              type="submit"
-              onClick={handleSendCode}
-              className="w-full bg-gray-400 text-white rounded-lg"
-            >
+            <Button onClick={handleSendCode} className="bg-gray-400 text-white">
               인증코드 전송
             </Button>
           </div>
         </>
       )}
-      
-      {/* 3단계: 인증코드 확인 */}
+
       {formStep === 'verify' && (
         <>
-          <h2 className="text-xl font-semibold text-gray-800">인증코드 입력</h2>
-          <p className="text-sm text-gray-600">{phone} 로 전송된 인증코드를 입력하세요.</p>
-          <div className="grid grid-col-1 grid-flow-col gap-3">
+          <h2 className="text-xl font-semibold text-gray-800">인증코드 확인</h2>
+          <p className="text-sm text-gray-600">{phone}로 전송된 인증코드를 입력해주세요.</p>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
             <Input
               type="text"
-              placeholder="인증코드 입력 (예: 123456)"
+              placeholder="인증코드 (예: 123456)"
               value={code}
-              maxLength={6}
               onChange={(e) => setCode(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleVerifySubmit()}
-              className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
+              maxLength={6}
+              className="w-full border border-gray-300 rounded-lg px-4 py-2"
             />
-            <Button
-              type="submit"
-              onClick={handleVerifySubmit}
-              className="w-full bg-gray-400 text-white rounded-lg py-2 transition"
-            >
+            <Button onClick={handleVerifySubmit} className="bg-primary text-white hover:bg-primary-dark">
               인증 완료
-            </Button>
-          </div>
-          
-          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-            <Button
-              onClick={() => setFormStep('phone')}
-              className="flex-1 bg-gray-200 text-gray-700 hover:bg-gray-300"
-            >
-              이전
-            </Button>
-            <Button
-              type="submit"
-              onClick={handleVerifySubmit}
-              className="w-full bg-primary text-white rounded-lg py-2 hover:bg-primary-dark transition"
-            >
-              확인
             </Button>
           </div>
         </>

--- a/src/components/AccountModal/ChangePhoneForm.jsx
+++ b/src/components/AccountModal/ChangePhoneForm.jsx
@@ -79,20 +79,24 @@ const ChangePhoneForm = () => {
     <form className="space-y-5 p-4 mt-5">
       {formStep === 'password' && (
         <>
-          <h2 className="text-xl font-semibold text-gray-800">비밀번호를 입력해주세요</h2>
+          <h2 className="text-xl font-semibold text-gray-800">비밀번호를 변경</h2>
           <div className="relative">
             <Input
               type={showPassword ? 'text' : 'password'}
-              placeholder="현재 비밀번호"
+              placeholder="현재 비밀번호 확인"
               value={password}
               onChange={(e) => setPassword(e.target.value)}
-              className="w-full border border-gray-300 rounded-lg px-4 py-2"
+              className="w-full border border-gray-300 rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-primary"
             />
             <span
               onClick={() => setShowPassword(!showPassword)}
-              className="absolute right-4 top-1/2 -translate-y-1/2 cursor-pointer"
+              className="absolute z-30 -translate-y-1/2 cursor-pointer right-4 top-1/2"
             >
-              {showPassword ? <EyeIcon className="size-5" /> : <EyeCloseIcon className="size-5" />}
+              {showPassword ? (
+                <EyeIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
+              ) : (
+                <EyeCloseIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
+              )}            
             </span>
           </div>
           <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">

--- a/src/components/AccountModal/WithdrawForm.jsx
+++ b/src/components/AccountModal/WithdrawForm.jsx
@@ -3,49 +3,60 @@ import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import { EyeCloseIcon, EyeIcon } from "../../icons";
+import { verifyPassword, deleteAccount } from '../../services/authService';
 
 const WithdrawForm = () => {
-  const [formStep, setFormStep] = useState('withdraw')
-  const [showPassword, setShowPassword] = useState(false);;
-  const { closeModal } = useAccountModalStore();
+  const [formStep, setFormStep] = useState('withdraw');
+  const [showPassword, setShowPassword] = useState(false);
   const [password, setPassword] = useState('');
-
-  const handleWithdrawSubmit = () => {
-    if (!password.trim()) {
-      alert('비밀번호를 입력해주세요.');
-      return;
-    }
-    setFormStep('complete');
-  };
+  const { closeModal } = useAccountModalStore();
 
   const handleConfirmSubmit = (e) => {
     e.preventDefault();
     setFormStep('confirm');
   };
-  
-  const handleComplete = (e) => {
-    e.preventDefault();
-    alert('회원 탈퇴가 완료되었습니다.');
+
+  const handleWithdrawSubmit = async () => {
+    if (!password.trim()) {
+      alert('비밀번호를 입력해주세요.');
+      return;
+    }
+
+    try {
+      const response = await verifyPassword({ password });
+      const reauthToken = response.data.data.reauthToken;
+
+      await deleteAccount(reauthToken);
+      setFormStep('complete');
+
+      sessionStorage.removeItem('reauthToken');
+      localStorage.clear();
+    } catch (err) {
+      alert(err.response?.data?.message || '회원 탈퇴에 실패했습니다.');
+    }
+  };
+
+  const handleComplete = () => {
     closeModal();
-  }
+    window.location.href = '/';
+  };
+
   return (
     <div className="p-4 mt-5">
-    {formStep === 'withdraw' && (
-      <div className="space-y-5">
-        <h2 className="text-xl font-semibold text-red-600">회원 탈퇴 안내</h2>
-        <p className="text-sm text-gray-600">정말로 계정을 삭제하시겠습니까?</p>
-        <div className="">
+      {formStep === 'withdraw' && (
+        <div className="space-y-5">
+          <h2 className="text-xl font-semibold text-red-600">회원 탈퇴 안내</h2>
+          <p className="text-sm text-gray-600">정말로 계정을 삭제하시겠습니까?</p>
           <Button
-            type="submit"
             onClick={handleConfirmSubmit}
             className="w-full mt-5 bg-red-600 text-white rounded-lg py-2 hover:bg-red-700 transition"
           >
             탈퇴하기
           </Button>
         </div>
-      </div>
-    )}
-      { formStep === 'confirm' && (
+      )}
+
+      {formStep === 'confirm' && (
         <>
           <h2 className="text-xl font-semibold text-red-600 mb-4">회원 탈퇴</h2>
           <p className="text-gray-600 mb-4">
@@ -54,24 +65,24 @@ const WithdrawForm = () => {
             <span className="text-red-500 text-sm">탈퇴 후 모든 데이터는 복구할 수 없습니다.</span>
           </p>
           <div className="space-y-4">
-          <div className="relative">
-            <Input
-              placeholder="비밀번호를 입력하세요"
-              value={password}
-              type={showPassword ? "text" : "password"}
-              onChange={(e) => setPassword(e.target.value)}
-              onKeyDown={(e) => e.key === 'Enter' && handleWithdrawSubmit()}
-            />
-            <span
-              onClick={() => setShowPassword(!showPassword)}
-              className="absolute z-30 -translate-y-1/2 cursor-pointer right-4 top-1/2"
-            >
-              {showPassword ? (
-                <EyeIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
-              ) : (
-                <EyeCloseIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
-              )}
-            </span>
+            <div className="relative">
+              <Input
+                placeholder="비밀번호를 입력하세요"
+                value={password}
+                type={showPassword ? "text" : "password"}
+                onChange={(e) => setPassword(e.target.value)}
+                onKeyDown={(e) => e.key === 'Enter' && handleWithdrawSubmit()}
+              />
+              <span
+                onClick={() => setShowPassword(!showPassword)}
+                className="absolute z-30 -translate-y-1/2 cursor-pointer right-4 top-1/2"
+              >
+                {showPassword ? (
+                  <EyeIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
+                ) : (
+                  <EyeCloseIcon className="fill-gray-500 dark:fill-gray-400 size-5" />
+                )}
+              </span>
             </div>
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
               <Button
@@ -90,6 +101,7 @@ const WithdrawForm = () => {
           </div>
         </>
       )}
+
       {formStep === 'complete' && (
         <div className="text-center">
           <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center mb-4">
@@ -109,4 +121,5 @@ const WithdrawForm = () => {
     </div>
   );
 };
+
 export default WithdrawForm;

--- a/src/components/AccountModal/WithdrawForm.jsx
+++ b/src/components/AccountModal/WithdrawForm.jsx
@@ -3,7 +3,7 @@ import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import { EyeCloseIcon, EyeIcon } from "../../icons";
-import { verifyPassword, deleteAccount } from '../../services/authService';
+import { verifyPassword, deleteAccount, logout } from '../../services/authService';
 
 const WithdrawForm = () => {
   const [formStep, setFormStep] = useState('withdraw');
@@ -27,10 +27,12 @@ const WithdrawForm = () => {
       const reauthToken = response.data.data.reauthToken;
 
       await deleteAccount(reauthToken);
-      setFormStep('complete');
+      await logout(); // ✅ 로그아웃 처리 (토큰 제거 + 서버 세션 종료)
 
-      sessionStorage.removeItem('reauthToken');
+      sessionStorage.clear(); // ✅ 모든 저장소 정리
       localStorage.clear();
+
+      setFormStep('complete');
     } catch (err) {
       alert(err.response?.data?.message || '회원 탈퇴에 실패했습니다.');
     }
@@ -38,7 +40,7 @@ const WithdrawForm = () => {
 
   const handleComplete = () => {
     closeModal();
-    window.location.href = '/';
+    window.location.href = '/'; // 홈 또는 로그인 화면으로 이동
   };
 
   return (

--- a/src/components/UserProfile/UserInfoEdit.jsx
+++ b/src/components/UserProfile/UserInfoEdit.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react';
+import { useNavigate } from "react-router-dom";
 import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
@@ -12,6 +13,7 @@ const UserInfoEdit = () => {
   const [phone, setPhone] = useState("");
   const { user } = useAuthStore();
   const { openStep } = useAccountModalStore(); 
+  const navigate = useNavigate();
 
   useEffect(() => {
     if (user) {
@@ -41,9 +43,9 @@ const UserInfoEdit = () => {
 
   const handleSave = (e) => {
     e.preventDefault();
-    // Handle save logic here
     console.log("Saving changes...", { username, email, phone, password });
     alert("변경사항이 저장되었습니다.");
+    navigate("/profile");
   };
   return (
     <>

--- a/src/components/UserProfile/UserInfoEdit.jsx
+++ b/src/components/UserProfile/UserInfoEdit.jsx
@@ -1,13 +1,21 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import useAccountModalStore from '../../store/useAccountModalStore';
 import Button from "../ui/button/Button";
 import Input from "../form/input/InputField";
 import Label from "../form/Label";
+import useAuthStore from '../../store/useAuthStore';
 
 const UserInfoEdit = () => {
   const [password, setPassword] = useState("");
   const [phone, setPhone] = useState("");
+  const { user } = useAuthStore();
   const { openStep } = useAccountModalStore(); 
+
+  useEffect(() => {
+    if (user && user.phoneNumber) {
+      setPhone(user.phoneNumber); // ✅ 초기값 설정
+    }
+  }, [user]);
   
   const openPhoneChange = (e) => {
     e.preventDefault();
@@ -29,7 +37,7 @@ const UserInfoEdit = () => {
   const handleSave = (e) => {
     e.preventDefault();
     // Handle save logic here
-    console.log("Saving changes...");
+    console.log("Saving changes...", phone);
     alert("변경사항이 저장되었습니다.");
   };
   return (
@@ -62,12 +70,18 @@ const UserInfoEdit = () => {
                             <Label>전화번호</Label>
                             <div className="relative pr-32">
                                 <Input
-                                placeholder="010-0000-0000"
+                                placeholder="01000000000"
                                 type="text"
                                 value={phone}
                                 onChange={(e) => setPhone(e.target.value)}
                                 />
-                                <Button className="absolute right-0 top-0" disabled={phone.trim() === ""} onClick={openPhoneChange}>전화번호 변경</Button>
+                                <Button 
+                                    className="absolute right-0 top-0" 
+                                    disabled={phone.trim() === ""} 
+                                    onClick={openPhoneChange}
+                                >
+                                    전화번호 변경
+                                </Button>
                             </div>
                         </div>
                         <div className="col-span-2 lg:col-span-1 mt-5">

--- a/src/components/UserProfile/UserInfoEdit.jsx
+++ b/src/components/UserProfile/UserInfoEdit.jsx
@@ -6,14 +6,19 @@ import Label from "../form/Label";
 import useAuthStore from '../../store/useAuthStore';
 
 const UserInfoEdit = () => {
+  const [username, setUsername] = useState("");
+  const [email, setEmail] = useState("");
   const [password, setPassword] = useState("");
   const [phone, setPhone] = useState("");
   const { user } = useAuthStore();
   const { openStep } = useAccountModalStore(); 
 
   useEffect(() => {
-    if (user && user.phoneNumber) {
-      setPhone(user.phoneNumber); // ✅ 초기값 설정
+    if (user) {
+      setUsername(user.username || "");
+      setEmail(user.email || "");
+      setPhone(user.phoneNumber || "");
+      setPassword("");
     }
   }, [user]);
   
@@ -37,7 +42,7 @@ const UserInfoEdit = () => {
   const handleSave = (e) => {
     e.preventDefault();
     // Handle save logic here
-    console.log("Saving changes...", phone);
+    console.log("Saving changes...", { username, email, phone, password });
     alert("변경사항이 저장되었습니다.");
   };
   return (
@@ -54,12 +59,12 @@ const UserInfoEdit = () => {
                     <div className="mt-5">
                         <div className="col-span-2 lg:col-span-1">
                             <Label>이름</Label>
-                            <Input type="text" disabled placeholder="홍길동" />
+                            <Input type="text" disabled placeholder={username} />
                         </div>
 
                         <div className="col-span-2 lg:col-span-1 mt-5">
                             <Label>이메일 주소</Label>
-                            <Input type="text" disabled placeholder="randomuser@pimjo.com" />
+                            <Input type="text" disabled placeholder={email} />
                         </div>
                     </div>
                     <div className="mt-7">
@@ -92,7 +97,12 @@ const UserInfoEdit = () => {
                                     placeholder="*********"
                                     value={password}
                                     onChange={(e) => setPassword(e.target.value)} />
-                                <Button className="absolute right-0 top-0" disabled={password.trim() === ""} onClick={openPasswordChange}>비밀번호 변경</Button>
+                                <Button 
+                                    className="absolute right-0 top-0" 
+                                    onClick={openPasswordChange}
+                                >
+                                    비밀번호 변경
+                                </Button>
                             </div>
                         </div>
                     </div>

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -120,3 +120,18 @@ export const changePassword = (newPassword, newPasswordCheck, reauthToken) => {
     }
   );
 };
+
+// 전화번호 변경
+export const verifyPhoneCodeAndChangeNumber = async ({ phoneNumber, reauthToken }) => {
+  const response = await axios.patch(
+    "https://3.39.233.161/api/users/me/phone",
+    { phoneNumber },
+    {
+      headers: {
+        Authorization: `Bearer ${reauthToken}`,
+      },
+      withCredentials: true,
+    }
+  );
+  return response.data;
+};

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -1,4 +1,5 @@
 import axiosInstance from "../libs/axiosInstance";
+import axios from "axios";
 
 // 로그인 요청 (일반/관리자 구분)
 export const login = async ({ email, password }) => {
@@ -104,4 +105,18 @@ export const myProfile = async () => {
 // 비밀번호 인증
 export const verifyPassword = async ({ password }) => {
   return axiosInstance.post("/api/users/password/verify", { password });
+};
+
+// 비밀번호 변경
+export const changePassword = (newPassword, newPasswordCheck, reauthToken) => {
+  return axios.patch(
+    "https://3.39.233.161/api/users/me/password", // 풀 URL로
+    { newPassword, newPasswordCheck },
+    {
+      headers: {
+        Authorization: `Bearer ${reauthToken}`,
+      },
+      withCredentials: true, // 쿠키 필요 시
+    }
+  );
 };

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -100,3 +100,8 @@ export const myProfile = async () => {
   const response = await axiosInstance.get("/api/users/me");
   return response.data;
 };
+
+// 비밀번호 인증
+export const verifyPassword = async ({ password }) => {
+  return axiosInstance.post("/api/users/password/verify", { password });
+};

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -135,3 +135,19 @@ export const verifyPhoneCodeAndChangeNumber = async ({ phoneNumber, reauthToken 
   );
   return response.data;
 };
+
+// 회원 탈퇴 요청
+export const deleteAccount = async (reauthToken) => {
+  const response = await axios.patch(
+    "https://3.39.233.161/api/users/me/status",
+    { status: "deleted" },
+    {
+      headers: {
+        Authorization: `Bearer ${reauthToken}`,
+      },
+      withCredentials: true,
+    }
+  );
+  return response.data;
+};
+


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 비밀번호 / 전화번호 변경 및 회원 탈퇴 기능 구현

---

## 📌 작업 내용 요약

- 비밀번호 변경 기능
   - 비밀번호 인증(verifyPassword) 후 reauthToken 발급
   - 새 비밀번호 입력 → 서버에 PATCH 요청
   - 변경 완료 시 알림 및 리디렉션 처리

- 전화번호 변경 기능
   - 비밀번호 인증(verifyPassword) → reauthToken 발급
   - 새 전화번호로 인증번호 발송 → 인증번호 확인
   - 인증 성공 시 전화번호 변경 API 호출

- 회원 탈퇴 기능
   - 탈퇴 확인 → 비밀번호 인증 후 reauthToken 발급
   - 상태값을 { "status": "deleted" }로 변경
   - 스토리지 초기화 및 홈 리디렉션

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #53 
- Closes #52 
- Closes #51 

---

## 📎 기타 참고 사항

- reauthToken은 인증 완료 후 sessionStorage에 임시 저장됨
- 모든 민감 작업(PATCH)은 Authorization: Bearer reauthToken을 헤더에 포함
