### PR TITLE
Feature/admin user status change

### DIFF
--- a/src/components/tables/BasicTables/DashboardTable.jsx
+++ b/src/components/tables/BasicTables/DashboardTable.jsx
@@ -14,6 +14,7 @@ import Pagination from "../../ui/pagination/pagination";
 import {
   fetchDashboardUsers,
   searchUsers,
+  statusChange,
 } from "../../../services/authService";
 
 const DashboardTable = () => {
@@ -73,6 +74,51 @@ const DashboardTable = () => {
 
     loadUsers();
   }, [page, searchQuery, searchType, statusFilter, emailCheckFilter]);
+
+  const handleStatusChange = async (userId, newStatus) => {
+    const confirmMessage =
+      newStatus === "deleted"
+        ? "정말로 이 회원을 삭제하시겠습니까?"
+        : "이 회원을 활성화하시겠습니까?";
+
+    if (window.confirm(confirmMessage)) {
+      try {
+        setLoading(true);
+        await statusChange(userId, newStatus);
+        console.log(`회원 ${userId}의 상태가 ${newStatus}로 변경되었습니다.`);
+
+        // 현재 페이지의 데이터만 다시 로드 (페이지 새로고침 대신)
+        const filters = {};
+        if (statusFilter !== "ALL") {
+          filters.status = statusFilter.toLowerCase();
+        }
+        if (emailCheckFilter !== "ALL") {
+          filters.emailVerified = emailCheckFilter.toLowerCase() === "true";
+        }
+
+        let res;
+        if (searchQuery.trim()) {
+          res = await searchUsers(
+            searchType,
+            searchQuery,
+            page,
+            itemsPerPage,
+            filters
+          );
+        } else {
+          res = await fetchDashboardUsers(page, itemsPerPage, filters);
+        }
+
+        setTableData(res.users);
+        setTotalItems(res.totalElements);
+      } catch (error) {
+        console.error("상태 변경 실패:", error);
+        alert("상태 변경에 실패했습니다.");
+      } finally {
+        setLoading(false);
+      }
+    }
+  };
 
   return (
     <div>
@@ -235,7 +281,7 @@ const DashboardTable = () => {
                     </TableCell>
                     <TableCell className="px-4 py-3 text-gray-500 text-theme-sm dark:text-gray-400">
                       <button
-                        onClick={() => console.log(`Edit item ${user.id}`)}
+                        onClick={() => handleStatusChange(user.id, "deleted")}
                         className="hover:text-blue-500 transition-colors duration-200"
                       >
                         <Trash2 size={16} />

--- a/src/components/tables/BasicTables/DashboardTable.jsx
+++ b/src/components/tables/BasicTables/DashboardTable.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { Trash2 } from "lucide-react";
+import { Trash2, Activity } from "lucide-react";
 
 import {
   Table,
@@ -15,6 +15,7 @@ import {
   fetchDashboardUsers,
   searchUsers,
   statusChange,
+  verifyPassword
 } from "../../../services/authService";
 
 const DashboardTable = () => {
@@ -81,44 +82,41 @@ const DashboardTable = () => {
         ? "정말로 이 회원을 삭제하시겠습니까?"
         : "이 회원을 활성화하시겠습니까?";
 
-    if (window.confirm(confirmMessage)) {
-      try {
-        setLoading(true);
-        await statusChange(userId, newStatus);
-        console.log(`회원 ${userId}의 상태가 ${newStatus}로 변경되었습니다.`);
+    if (!window.confirm(confirmMessage)) return;
 
-        // 현재 페이지의 데이터만 다시 로드 (페이지 새로고침 대신)
-        const filters = {};
-        if (statusFilter !== "ALL") {
-          filters.status = statusFilter.toLowerCase();
-        }
-        if (emailCheckFilter !== "ALL") {
-          filters.emailVerified = emailCheckFilter.toLowerCase() === "true";
-        }
-
-        let res;
-        if (searchQuery.trim()) {
-          res = await searchUsers(
-            searchType,
-            searchQuery,
-            page,
-            itemsPerPage,
-            filters
-          );
-        } else {
-          res = await fetchDashboardUsers(page, itemsPerPage, filters);
-        }
-
-        setTableData(res.users);
-        setTotalItems(res.totalElements);
-      } catch (error) {
-        console.error("상태 변경 실패:", error);
-        alert("상태 변경에 실패했습니다.");
-      } finally {
-        setLoading(false);
+    try {
+      const password = prompt("관리자 비밀번호를 입력하세요");
+      if (!password) {
+        alert("비밀번호가 입력되지 않았습니다.");
+        return;
       }
+
+      const response = await verifyPassword({ password });
+      const reauthToken = response.data.data.reauthToken;
+
+      sessionStorage.setItem("reauthToken", reauthToken);
+
+      setLoading(true);
+      await statusChange(userId, newStatus, reauthToken);
+
+      const filters = {};
+      if (statusFilter !== "ALL") filters.status = statusFilter.toLowerCase();
+      if (emailCheckFilter !== "ALL") filters.emailVerified = emailCheckFilter.toLowerCase() === "true";
+
+      const res = searchQuery.trim()
+        ? await searchUsers(searchType, searchQuery, page, itemsPerPage, filters)
+        : await fetchDashboardUsers(page, itemsPerPage, filters);
+
+      setTableData(res.users);
+      setTotalItems(res.totalElements);
+    } catch (error) {
+      console.error("상태 변경 실패:", error);
+      alert(error?.response?.data?.message || "상태 변경에 실패했습니다. 비밀번호를 확인해주세요.");
+    } finally {
+      setLoading(false);
     }
   };
+
 
   return (
     <div>
@@ -280,12 +278,23 @@ const DashboardTable = () => {
                       </Badge>
                     </TableCell>
                     <TableCell className="px-4 py-3 text-gray-500 text-theme-sm dark:text-gray-400">
-                      <button
-                        onClick={() => handleStatusChange(user.id, "deleted")}
-                        className="hover:text-blue-500 transition-colors duration-200"
-                      >
-                        <Trash2 size={16} />
-                      </button>
+                      {user.status === "deleted" ? (
+                        <button
+                          onClick={() => handleStatusChange(user.id, "active")}
+                          className="hover:text-green-500 transition-colors duration-200"
+                          title="복구하기"
+                        >
+                          <Activity size={16} />
+                        </button>
+                      ) : (
+                        <button
+                          onClick={() => handleStatusChange(user.id, "deleted")}
+                          className="hover:text-red-500 transition-colors duration-200"
+                          title="삭제하기"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      )}
                     </TableCell>
                   </TableRow>
                 ))}

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -104,7 +104,6 @@ export const myProfile = async () => {
   return response.data;
 };
 
-
 // 비밀번호 인증
 export const verifyPassword = async ({ password }) => {
   return axiosInstance.post("/api/users/password/verify", { password });
@@ -125,7 +124,10 @@ export const changePassword = (newPassword, newPasswordCheck, reauthToken) => {
 };
 
 // 전화번호 변경
-export const verifyPhoneCodeAndChangeNumber = async ({ phoneNumber, reauthToken }) => {
+export const verifyPhoneCodeAndChangeNumber = async ({
+  phoneNumber,
+  reauthToken,
+}) => {
   const response = await axios.patch(
     "https://3.39.233.161/api/users/me/phone",
     { phoneNumber },
@@ -182,3 +184,10 @@ export const checkEmailDuplicate = async (email) => {
   return response.data;
 };
 
+// 회원 상태 변경
+export const statusChange = async (id, status) => {
+  const response = await axiosInstance.patch(`/api/admin/users/status/${id}`, {
+    status,
+  });
+  return response.data;
+};

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -185,9 +185,15 @@ export const checkEmailDuplicate = async (email) => {
 };
 
 // 회원 상태 변경
-export const statusChange = async (id, status) => {
-  const response = await axiosInstance.patch(`/api/admin/users/status/${id}`, {
-    status,
-  });
+export const statusChange = async (userId, newStatus, reauthToken) => {
+  const response = await axios.patch(
+    `https://3.39.233.161/api/admin/users/status/${userId}`,
+    { status: newStatus },
+    {
+      headers: {
+        Authorization: `Bearer ${reauthToken}`,
+      },
+    }
+  );
   return response.data;
 };


### PR DESCRIPTION
## 🔀 PR 제목
- [Feature] 회원 정보 보안 기능 구현 (비밀번호/전화번호 변경, 회원 탈퇴)
- [Fix] 상태 변경 시 비밀번호 인증 오류 처리

---

## 📌 작업 내용 요약

- 관리자 대시보드에서 회원 상태 변경 기능 구현 (삭제 및 복구
- 공통적으로 민감 정보 변경 전 비밀번호 재인증 로직 적용
- sessionStorage에 reauthToken 저장 및 인증 API에 활용
- authService.js에 관련 API 함수 추가

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #55 

---

## 📎 기타 참고 사항

- 각 민감 작업에 대해 동일한 인증 흐름을 재사용할 수 있도록 verifyPassword 응답에서 받은 reauthToken을 세션에 저장
- UI는 기존 컴포넌트를 유지하면서 최소한의 변경으로 기능 구현 완료됨
