### PR TITLE
Feature/token

### DIFF
--- a/src/libs/axiosInstance.js
+++ b/src/libs/axiosInstance.js
@@ -1,7 +1,9 @@
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  baseURL: "https://3.39.233.161/",
+  // baseURL: "https://3.39.233.161/",
+    baseURL: "http://localhost:8080/",
+
   withCredentials: true,
 });
 

--- a/src/libs/axiosInstance.js
+++ b/src/libs/axiosInstance.js
@@ -1,21 +1,53 @@
 import axios from "axios";
 
 const axiosInstance = axios.create({
-  // baseURL: "https://3.39.233.161/",
-    baseURL: "http://localhost:8080/",
-
+  baseURL: "https://3.39.233.161/",
   withCredentials: true,
 });
 
 axiosInstance.interceptors.request.use((config) => {
-  const token =
-    localStorage.getItem("accessToken") ||
-    sessionStorage.getItem("accessToken");
-
+  const token = sessionStorage.getItem("accessToken");
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
   return config;
 });
 
+axiosInstance.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+
+    if (
+      error.response?.status === 401 &&
+      !originalRequest._retry &&
+      !originalRequest.url.includes("/auth/token/refresh")
+    ) {
+      originalRequest._retry = true;
+
+      try {
+        const res = await axios.post(
+          "https://3.39.233.161/api/auth/token/refresh",
+          {},
+          {
+            withCredentials: true,
+          }
+        );
+
+        const newAccessToken = res.data.data.accessToken;
+
+        sessionStorage.setItem("accessToken", newAccessToken);
+
+        originalRequest.headers.Authorization = `Bearer ${newAccessToken}`;
+        return axiosInstance(originalRequest);
+      } catch (refreshErr) {
+        console.error("토큰 재발급 실패", refreshErr);
+        sessionStorage.removeItem("accessToken");
+        window.location.href = "/login"; 
+      }
+    }
+
+    return Promise.reject(error);
+  }
+);
 export default axiosInstance;

--- a/src/services/authService.js
+++ b/src/services/authService.js
@@ -13,7 +13,29 @@ export const login = async ({ email, password }) => {
 // 로그아웃 요청
 export const logout = async (isAdmin = false) => {
   const url = isAdmin ? "/api/admin/signout" : "/api/signout";
-  return await axiosInstance.post(url);
+  const accessToken = sessionStorage.getItem("accessToken");
+
+  try {
+    const res = await axiosInstance.post(
+      url,
+      {},
+      {
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+        withCredentials: true,
+      }
+    );
+
+    // ✅ accessToken 삭제
+    sessionStorage.removeItem("accessToken");
+
+    return res.data;
+  } catch (err) {
+    console.warn("로그아웃 중 오류 발생", err);
+    sessionStorage.removeItem("accessToken"); // 실패해도 제거는 함
+    throw err;
+  }
 };
 
 // 인증번호 발송


### PR DESCRIPTION
## 🔀 PR 제목

- [Feature] 토큰 재발급 및 로그아웃 시 토큰 만료 처리 기능 구현

---

## 📌 작업 내용 요약

- accessToken 만료 시 refreshToken 쿠키를 사용하여 자동 재발급되도록 axios 응답 인터셉터 구현
- 재발급 성공 시 새로운 accessToken을 sessionStorage에 저장하고, 실패 시 로그인 페이지로 이동
- 로그아웃 시 accessToken을 삭제하고, refreshToken 쿠키를 서버에서 만료 처리
- 관리자/일반 사용자 공통으로 적용되며, 로그아웃 후 로그인 페이지로 리다이렉트

---

## ✅ 체크리스트

- [ ] 기능 요구사항을 모두 구현했나요?
- [ ] 로컬에서 기능을 직접 테스트했나요?
- [ ] 코드 컨벤션 및 스타일을 지켰나요?
- [ ] 관련된 이슈에 연결했나요?

---

## 🔗 관련 이슈

- Closes #59 
- Closes #57 

---

## 📎 기타 참고 사항

- axiosInstance.js에 응답 인터셉터 로직 추가
- /api/auth/token/refresh 요청 시 쿠키를 포함해야 하므로 withCredentials: true 필수
- 로그아웃 시 서버에서 Set-Cookie로 refreshToken 만료 쿠키 전달됨 (maxAge: 0)
- 인증 흐름 테스트 완료 (accessToken 만료 → 자동 재발급 / 쿠키 삭제 시 재로그인 유도)


